### PR TITLE
Refactor tester callback around kitchen-ssh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ gem 'pry'
 gem 'minitest'
 gem 'carnivore-actor'
 
-gem 'kitchen-ssh'
-
 %w(
   jackal
   jackal-assets

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'pry'
 gem 'minitest'
 gem 'carnivore-actor'
 
-gem 'kitchen-vagrant'
+gem 'kitchen-ssh'
 
 %w(
   jackal

--- a/jackal-kitchen.gemspec
+++ b/jackal-kitchen.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'carnivore-http'
   s.add_dependency 'carnivore-actor'
   s.add_dependency 'test-kitchen', '~> 1.3.0'
+  s.add_dependency 'kitchen-ssh', '~> 0.0.8'
   s.add_dependency 'rye', '~> 0.9.13'
   s.files = Dir['lib/**/*'] + %w(jackal-kitchen.gemspec README.md CHANGELOG.md CONTRIBUTING.md LICENSE)
 end

--- a/jackal-kitchen.gemspec
+++ b/jackal-kitchen.gemspec
@@ -15,5 +15,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'carnivore-http'
   s.add_dependency 'carnivore-actor'
   s.add_dependency 'test-kitchen', '~> 1.3.0'
+  s.add_dependency 'rye', '~> 0.9.13'
   s.files = Dir['lib/**/*'] + %w(jackal-kitchen.gemspec README.md CHANGELOG.md CONTRIBUTING.md LICENSE)
 end

--- a/jackal-kitchen.gemspec
+++ b/jackal-kitchen.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'childprocess'
   s.add_dependency 'carnivore-http'
   s.add_dependency 'carnivore-actor'
-  s.add_dependency 'test-kitchen', '~> 1.2.0'
+  s.add_dependency 'test-kitchen', '~> 1.3.0'
   s.files = Dir['lib/**/*'] + %w(jackal-kitchen.gemspec README.md CHANGELOG.md CONTRIBUTING.md LICENSE)
 end

--- a/lib/jackal-kitchen/adjudicate.rb
+++ b/lib/jackal-kitchen/adjudicate.rb
@@ -168,7 +168,7 @@ module Jackal
 
       def chef_run_failed?(payload, type, instance)
         return false unless type.to_sym == :teapot
-        test_output(payload, :teapot)[instance][:run_status][:run_failed]
+        test_output(payload, :teapot).fetch(instance, :run_status, :run_failed, false)
       end
 
     end

--- a/lib/jackal-kitchen/formatter/github_status.rb
+++ b/lib/jackal-kitchen/formatter/github_status.rb
@@ -18,7 +18,10 @@ module Jackal
           success = payload.get(:data, :kitchen, :judge, :decision)
           payload.set(:data, :github_kit, :status,
                       Smash.new(
-                        :repository => payload.get(:data, :code_fetcher, :info, :name),
+                        :repository => [
+                          payload.get(:data, :code_fetcher, :info, :owner),
+                          payload.get(:data, :code_fetcher, :info, :name)
+                        ].join('/'),
                         :reference => payload.get(:data, :code_fetcher, :info, :commit_sha),
                         :state => payload.get(:data, :kitchen, :judge, :decision) ? 'success' : 'failure'),
                      )

--- a/lib/jackal-kitchen/tester.rb
+++ b/lib/jackal-kitchen/tester.rb
@@ -135,7 +135,7 @@ module Jackal
         Smash.new(
           :host => config[:ssh][:host],
           :port => config[:ssh][:port],
-          :user => config[:ssh][:username],
+          :user => config[:ssh][:user],
           :key => config[:ssh][:key],
         )
       end

--- a/lib/jackal-kitchen/tester.rb
+++ b/lib/jackal-kitchen/tester.rb
@@ -64,7 +64,17 @@ module Jackal
               instances = kitchen_instances(working_dir)
               payload.set(:data, :kitchen, :instances, instances)
               instances.each do |instance|
-                run_commands(["bundle exec kitchen test #{instance}"], {}, working_dir, payload)
+                run_commands(["bundle exec kitchen verify #{instance}"], {}, working_dir, payload)
+                remote = provision_instance
+                connection = Rye::Box.new(
+                  remote[:host],
+                  :port => remote[:port],
+                  :user => remote[:user],
+                  :keys => remote[:key],
+                  :password => 'invalid',
+                  :password_prompt => false
+                )
+
                 %w(teapot serverspec).each do |format|
                   parse_test_output(payload, {
                     :format => format.to_sym, :cwd => output_path, :instance => instance

--- a/lib/jackal-kitchen/tester.rb
+++ b/lib/jackal-kitchen/tester.rb
@@ -135,15 +135,19 @@ module Jackal
         )
       end
 
-      def insert_kitchen_local(path)
+      # Write .kitchen.local.yml overrides into specified path
+      #
+      # @param path [String]
+      # @param instance [Hash]
+      def insert_kitchen_local(path, instance = {})
         File.open(File.join(path, '.kitchen.local.yml'), 'w') do |file|
           file.puts '---'
           file.puts 'driver:'
           file.puts '  name: ssh'
-          file.puts "  hostname: #{config[:ssh][:hostname]}"
-          file.puts "  username: #{config[:ssh][:username]}"
-          file.puts "  port: #{config[:ssh][:port]}"
-          file.puts "  ssh_key: #{config[:ssh][:key]}"
+          file.puts "  hostname: #{instance[:host]}"
+          file.puts "  username: #{instance[:user]}"
+          file.puts "  port: #{instance[:port]}"
+          file.puts "  ssh_key: #{instance[:key]}"
         end
       end
 

--- a/lib/jackal-kitchen/tester.rb
+++ b/lib/jackal-kitchen/tester.rb
@@ -97,6 +97,20 @@ module Jackal
         end
       end
 
+      # Create a remote instance and return information for accessing it via SSH
+      # TODO: Actually provision instances. For now, read ssh connection params from config.
+      #
+      # @param instance_config [Hash, Smash]
+      # @returns [Smash]
+      def provision_instance(instance_config = {})
+        Smash.new(
+          :host => config[:ssh][:host],
+          :port => config[:ssh][:port],
+          :user => config[:ssh][:username],
+          :key => config[:ssh][:key],
+        )
+      end
+
       def insert_kitchen_local(path)
         File.open(File.join(path, '.kitchen.local.yml'), 'w') do |file|
           file.puts '---'

--- a/lib/jackal-kitchen/tester.rb
+++ b/lib/jackal-kitchen/tester.rb
@@ -97,7 +97,14 @@ module Jackal
             FileUtils.rm_rf(working_dir)
           end
 
-          failures = payload.get(:data, :kitchen, :test_output, :teapot).any? do |instance, h|
+          teapot = payload.fetch(:data, :kitchen, :test_output, :teapot, {})
+
+          if teapot.empty?
+            error "No teapot test output data found"
+            raise
+          end
+
+          failures = teapot.any? do |instance, h|
             h.get(:run_status, :http_failure, :permanent) == false
           end
           retry_count = payload.fetch(:data, :kitchen, :retry_count, 0)

--- a/lib/jackal-kitchen/tester.rb
+++ b/lib/jackal-kitchen/tester.rb
@@ -132,12 +132,7 @@ module Jackal
       # @param instance_config [Hash]
       # @returns [Smash]
       def provision_instance(instance_config = {})
-        Smash.new(
-          :host => config[:ssh][:host],
-          :port => config[:ssh][:port],
-          :user => config[:ssh][:user],
-          :key => config[:ssh][:key],
-        )
+        config.fetch(:ssh, {})
       end
 
       # Write .kitchen.local.yml overrides into specified path


### PR DESCRIPTION
at the moment this implementation doesn't actually do anything to provision an instance, so it's assumed that you'll pass in some config for the instance to ssh into. Here's what I have for running kitchen on a local Vagrant-managed VM:

```
    kitchen do
      config do
        ssh do
          host 'localhost'
          user 'vagrant'
          port 2200
          key File.expand_path('~/.ssh/vagrant')
        end
        ...
      end
      ...
    end
```
